### PR TITLE
ui: flowsheet hover-table scale, palette icons on canvas, scaled sheet tab strip

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "external/ReoGrid"]
 	path = external/ReoGrid
-	url = https://github.com/DanWBR/ReoGrid
+	url = https://github.com/rzhli/ReoGrid
 	branch = avalonia

--- a/content/readme.txt
+++ b/content/readme.txt
@@ -178,7 +178,6 @@ Version 10.2
 - [FIX] Anaerobic Digester (ADM1-Full): the substrate is characterised from its elemental formula and fed as a composite particulate (carbohydrate/protein/lipid plus inerts), so the conversion is realistic and its nitrogen is released as ammonia instead of everything behaving like fully-degradable carbohydrate
 - [FIX] Anaerobic Digester: hydraulic loading is taken from the total feed instead of the flashed liquid phase, so a slurry feed no longer gets an unrealistically long retention time
 - [FIX] A chemical formula with fractional atom counts is parsed correctly, so a lumped biomass formula no longer drops its sulfur and the digester now produces H2S
-- [FIX] Cross-platform editors: a typed decimal such as 0.965 was misread as 965 in a locale whose group separator is a period, corrupting the composition; numeric input is now parsed without a thousands separator
 - [FIX] Property package editor: clicking Configure on a CAPE-OPEN property package no longer crashes
 - [FIX] Compound Creator: the Standard Enthalpy of Formation label is no longer clipped
 - [FIX] Pipe network: cloning a non-empty network no longer throws, the network block and its boundary streams are laid out on the flowsheet, and editing a network property no longer overwrites a Source feed

--- a/content/whatsnew.txt
+++ b/content/whatsnew.txt
@@ -114,7 +114,6 @@
 - [FIX] Anaerobic Digester (ADM1-Full): the substrate is characterised from its elemental formula and fed as a composite particulate (carbohydrate/protein/lipid plus inerts), so the conversion is realistic and its nitrogen is released as ammonia instead of everything behaving like fully-degradable carbohydrate
 - [FIX] Anaerobic Digester: hydraulic loading is taken from the total feed instead of the flashed liquid phase, so a slurry feed no longer gets an unrealistically long retention time
 - [FIX] A chemical formula with fractional atom counts is parsed correctly, so a lumped biomass formula no longer drops its sulfur and the digester now produces H2S
-- [FIX] Cross-platform editors: a typed decimal such as 0.965 was misread as 965 in a locale whose group separator is a period, corrupting the composition; numeric input is now parsed without a thousands separator
 - [FIX] Property package editor: clicking Configure on a CAPE-OPEN property package no longer crashes
 - [FIX] Compound Creator: the Standard Enthalpy of Formation label is no longer clipped
 - [FIX] Pipe network: cloning a non-empty network no longer throws, the network block and its boundary streams are laid out on the flowsheet, and editing a network property no longer overwrites a Source feed

--- a/engine/DWSIM.Drawing.SkiaSharp/GraphicObjects/Table/FloatingTable.vb
+++ b/engine/DWSIM.Drawing.SkiaSharp/GraphicObjects/Table/FloatingTable.vb
@@ -71,7 +71,8 @@ Namespace GraphicObjects.Tables
 
                 Dim canvas As SKCanvas = DirectCast(g, SKCanvas)
 
-                FontSize = 11.0
+                ' base 14 instead of 11 so the hover table reads well at any UI scaling
+                FontSize = 14.0
 
                 FontSize *= s.DpiScale * sf
 

--- a/engine/DWSIM.FlowsheetBase/FlowsheetBase.vb
+++ b/engine/DWSIM.FlowsheetBase/FlowsheetBase.vb
@@ -1636,7 +1636,7 @@ Imports DWSIM.ExtensionMethods
 
                 Dim myPump As New PumpGraphic(mpx, mpy, 25, 25)
                 If FlowsheetOptions.FlowsheetColorTheme = 2 Then
-                    myPump.SetSize(New SKSize(40, 40))
+                    myPump.SetSize(New SKSize(64, 64))
                 End If
                 myPump.LineWidth = 2
                 myPump.Fill = True
@@ -1673,7 +1673,7 @@ Imports DWSIM.ExtensionMethods
 
                 Dim myVessel As New VesselGraphic(mpx, mpy, 50, 50)
                 If FlowsheetOptions.FlowsheetColorTheme = 2 Then
-                    myVessel.SetSize(New SKSize(70, 60))
+                    myVessel.SetSize(New SKSize(96, 80))
                 End If
                 myVessel.LineWidth = 2
                 myVessel.Fill = True
@@ -1692,6 +1692,9 @@ Imports DWSIM.ExtensionMethods
             Case ObjectType.MaterialStream
 
                 Dim myMStr As New MaterialStreamGraphic(mpx, mpy, 20, 20)
+                If FlowsheetOptions.FlowsheetColorTheme = 2 Then
+                    myMStr.SetSize(New SKSize(40, 40))
+                End If
                 myMStr.LineWidth = 2
                 myMStr.Fill = True
                 myMStr.Tag = objindex
@@ -1728,7 +1731,7 @@ Imports DWSIM.ExtensionMethods
 
                 Dim myComp As New CompressorGraphic(mpx, mpy, 25, 25)
                 If FlowsheetOptions.FlowsheetColorTheme = 2 Then
-                    myComp.SetSize(New SKSize(50, 50))
+                    myComp.SetSize(New SKSize(80, 80))
                 End If
                 myComp.LineWidth = 2
                 myComp.Fill = True
@@ -1748,7 +1751,7 @@ Imports DWSIM.ExtensionMethods
 
                 Dim myComp As New TurbineGraphic(mpx, mpy, 25, 25)
                 If FlowsheetOptions.FlowsheetColorTheme = 2 Then
-                    myComp.SetSize(New SKSize(50, 50))
+                    myComp.SetSize(New SKSize(80, 80))
                 End If
                 myComp.LineWidth = 2
                 myComp.Fill = True
@@ -1801,7 +1804,7 @@ Imports DWSIM.ExtensionMethods
 
                 Dim myPipe As New PipeSegmentGraphic(mpx, mpy, 50, 10)
                 If FlowsheetOptions.FlowsheetColorTheme = 2 Then
-                    myPipe.SetSize(New SKSize(50, 20))
+                    myPipe.SetSize(New SKSize(80, 32))
                 End If
                 myPipe.LineWidth = 2
                 myPipe.Fill = True
@@ -1822,7 +1825,7 @@ Imports DWSIM.ExtensionMethods
                 Dim myValve As New ValveGraphic(mpx, mpy, 20, 20)
                 Dim myPipe As New PipeSegmentGraphic(mpx, mpy, 50, 10)
                 If FlowsheetOptions.FlowsheetColorTheme = 2 Then
-                    myValve.SetSize(New SKSize(30, 30))
+                    myValve.SetSize(New SKSize(48, 48))
                 End If
                 myValve.LineWidth = 2
                 myValve.Fill = True
@@ -1925,7 +1928,7 @@ Imports DWSIM.ExtensionMethods
 
                 Dim myHeatExchanger As New HeatExchangerGraphic(mpx, mpy, 30, 30)
                 If FlowsheetOptions.FlowsheetColorTheme = 2 Then
-                    myHeatExchanger.SetSize(New SKSize(60, 60))
+                    myHeatExchanger.SetSize(New SKSize(96, 96))
                 End If
                 myHeatExchanger.LineWidth = 2
                 myHeatExchanger.Fill = True

--- a/ui/DWSIM.UI.Desktop.Avalonia/App.axaml.cs
+++ b/ui/DWSIM.UI.Desktop.Avalonia/App.axaml.cs
@@ -32,6 +32,9 @@ public class App : Application
         // (scaling reverted to 1.0 every restart). Load them before anything reads them.
         try { DWSIM.GlobalSettings.Settings.LoadSettings("dwsim_newui.ini"); } catch { }
 
+        // UI-only preferences the engine ini has no slot for (hover table scale).
+        UiPreferences.Load();
+
         // Honor the persisted DarkMode flag. Engine wrote it last session; we read it here
         // before any window is shown so the choice is reflected from the splash onward.
         if (DWSIM.GlobalSettings.Settings.DarkMode)

--- a/ui/DWSIM.UI.Desktop.Avalonia/BulkPseudocompoundsWindow.cs
+++ b/ui/DWSIM.UI.Desktop.Avalonia/BulkPseudocompoundsWindow.cs
@@ -197,8 +197,8 @@ public sealed class BulkPseudocompoundsWindow : Window
     private static double? Parse(string s, int row, string caption)
     {
         if (string.IsNullOrWhiteSpace(s)) return null;
-        if (!double.TryParse(s.Trim(), NumberStyles.Float, CultureInfo.CurrentCulture, out var v) &&
-            !double.TryParse(s.Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out v))
+        if (!double.TryParse(s.Trim(), NumberStyles.Any, CultureInfo.CurrentCulture, out var v) &&
+            !double.TryParse(s.Trim(), NumberStyles.Any, CultureInfo.InvariantCulture, out v))
         {
             throw new Exception($"Error in row {row + 1}: {caption} is not a valid number.");
         }

--- a/ui/DWSIM.UI.Desktop.Avalonia/FlowsheetObjectIcons.cs
+++ b/ui/DWSIM.UI.Desktop.Avalonia/FlowsheetObjectIcons.cs
@@ -1,0 +1,251 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using SkiaSharp;
+using DWSIM.Interfaces;
+
+namespace DWSIM.UI.Desktop.Avalonia;
+
+/// <summary>
+/// Gives the two flowsheet colour themes distinct artwork instead of leaving "Default" on the
+/// schematic outline (a diamond with a "C", a circle with a zigzag):
+///
+///   Default     -> the flat icons the Objects palette shows, so the block you drop looks like the
+///                  thumbnail you dragged.
+///   Color Icons -> the photorealistic images the drawing assembly embeds, matching what the
+///                  external biochemical units already do in that theme.
+///
+/// Both use the engine's existing image path: <c>DrawMode = 2</c> makes ShapeGraphic.DrawPhoto blit
+/// whatever is in the object's photo fields. This class only decides which image goes in there.
+/// The other themes (black-and-white PFD, the gradient modes) are left untouched.
+///
+/// The two fields are Friend to the drawing assembly, hence the reflection. The lookups are cached
+/// and the class degrades to a no-op if a future engine version renames them, which just restores
+/// the stock rendering.
+/// </summary>
+internal static class FlowsheetObjectIcons
+{
+    private const int DefaultTheme = 0;
+    private const int ColorIconsTheme = 2;
+    private const int PhotoDrawMode = 2;
+
+    private static readonly Type GraphicObjectType =
+        typeof(DWSIM.Drawing.SkiaSharp.GraphicObjects.GraphicObject);
+
+    private static readonly FieldInfo? PhotoImageField =
+        GraphicObjectType.GetField("PhotoImage", BindingFlags.NonPublic | BindingFlags.Instance);
+
+    private static readonly FieldInfo? PhotoNameField =
+        GraphicObjectType.GetField("EmbeddedResourcePhotoName", BindingFlags.NonPublic | BindingFlags.Instance);
+
+    public static bool Available => PhotoImageField != null && PhotoNameField != null;
+
+    /// <summary>
+    /// Per-object artwork. Keyed weakly on the graphic object, so an object removed from the
+    /// flowsheet takes its entry with it and a re-added one starts clean.
+    /// </summary>
+    private sealed class State
+    {
+        /// <summary>The embedded photo the object was built with, captured before it is overwritten.</summary>
+        public string OriginalPhotoName = "";
+        public SKImage? PaletteIcon;
+        public SKImage? Photo;
+        public bool PaletteTried;
+        public bool PhotoTried;
+    }
+
+    private static readonly ConditionalWeakTable<IGraphicObject, State> _state = new();
+
+    /// <summary>
+    /// Streams are left alone: their graphic IS the connecting arrow, so an icon would hide where
+    /// the material goes.
+    /// </summary>
+    private static bool IsExcluded(Interfaces.Enums.GraphicObjects.ObjectType type) =>
+        type == Interfaces.Enums.GraphicObjects.ObjectType.MaterialStream ||
+        type == Interfaces.Enums.GraphicObjects.ObjectType.EnergyStream;
+
+    private static bool IsExternal(Interfaces.Enums.GraphicObjects.ObjectType type) =>
+        type == Interfaces.Enums.GraphicObjects.ObjectType.External;
+
+    /// <summary>
+    /// The private SKImage cache each external unit operation passes ByRef to
+    /// BioOpsDrawHelper.TryDrawPhotorealistic, looked up once per concrete type.
+    /// </summary>
+    private static readonly Dictionary<Type, FieldInfo?> _externalPhotoFields = new();
+
+    private static FieldInfo? ExternalPhotoField(Type type)
+    {
+        lock (_externalPhotoFields)
+        {
+            if (_externalPhotoFields.TryGetValue(type, out var cached)) return cached;
+
+            FieldInfo? found = null;
+            for (var t = type; t != null && found == null; t = t.BaseType)
+                found = t.GetField("_photoImage", BindingFlags.NonPublic | BindingFlags.Instance);
+
+            _externalPhotoFields[type] = found;
+            return found;
+        }
+    }
+
+    /// <summary>
+    /// Points every block at the artwork its theme calls for, and reports the theme value that has
+    /// to be restored once the frame is drawn.
+    ///
+    /// DesignSurface.UpdateCanvas opens every frame with UpdateColorTheme(), which overwrites each
+    /// object's DrawMode with FlowsheetOptions.FlowsheetColorTheme. Setting DrawMode here would
+    /// therefore be undone before anything is painted - under "Default" the blocks would keep
+    /// falling back to the outline. So the option itself is switched to the image mode for the
+    /// duration of the (synchronous) draw and put back in <see cref="EndDraw"/>, leaving the value
+    /// Simulation Settings reads untouched.
+    ///
+    /// Returns the theme to restore, or null when nothing was overridden.
+    /// </summary>
+    public static int? BeginDraw(IFlowsheet? flowsheet)
+    {
+        if (!Available || flowsheet == null) return null;
+        if (!UiPreferences.UsePaletteIconsOnCanvas) return null;
+
+        int theme;
+        try { theme = flowsheet.FlowsheetOptions.FlowsheetColorTheme; } catch { return null; }
+        if (theme != DefaultTheme && theme != ColorIconsTheme) return null;
+
+        List<ISimulationObject> objects;
+        try { objects = new List<ISimulationObject>(flowsheet.SimulationObjects.Values); }
+        catch { return null; }
+
+        foreach (var so in objects)
+        {
+            // Per object, so one type that misbehaves cannot abort the whole pass and leave the
+            // rest of the flowsheet on the outline rendering.
+            try
+            {
+                var gobj = so?.GraphicObject;
+                if (gobj == null || IsExcluded(gobj.ObjectType)) continue;
+
+                if (!_state.TryGetValue(gobj, out var state))
+                {
+                    state = new State();
+                    try { state.OriginalPhotoName = PhotoNameField!.GetValue(gobj) as string ?? ""; }
+                    catch { }
+                    _state.Add(gobj, state);
+                }
+
+                if (IsExternal(gobj.ObjectType))
+                    UseExternalArtwork(so!, state, wantPalette: theme == DefaultTheme);
+                else if (theme == DefaultTheme)
+                    UsePaletteIcon(so!, gobj, state);
+                else
+                    UseEmbeddedPhoto(gobj, state);
+            }
+            catch { }
+        }
+
+        if (theme == ColorIconsTheme) return null;   // already the mode UpdateColorTheme will set
+
+        try
+        {
+            flowsheet.FlowsheetOptions.FlowsheetColorTheme = PhotoDrawMode;
+            return theme;
+        }
+        catch { return null; }
+    }
+
+    /// <summary>Puts back the theme <see cref="BeginDraw"/> overrode. Safe to call with null.</summary>
+    public static void EndDraw(IFlowsheet? flowsheet, int? original)
+    {
+        if (flowsheet == null || original == null) return;
+        try { flowsheet.FlowsheetOptions.FlowsheetColorTheme = original.Value; } catch { }
+    }
+
+    /// <summary>
+    /// External unit operations (the biochemical blocks and friends) paint themselves in
+    /// IExternalUnitOperation.Draw, so the graphic object's photo fields never come into play.
+    /// What they do read, in the photo mode this class puts them into, is their own private SKImage
+    /// cache - which BioOpsDrawHelper only fills when it is empty. Writing the palette icon into
+    /// that cache is therefore enough to give them the same Default-theme look as every other block.
+    /// </summary>
+    private static void UseExternalArtwork(ISimulationObject so, State state, bool wantPalette)
+    {
+        var field = ExternalPhotoField(so.GetType());
+        if (field == null) return;
+
+        // Whatever the helper loaded for itself is the artwork to put back under Color Icons.
+        var current = field.GetValue(so) as SKImage;
+        if (current != null && !ReferenceEquals(current, state.PaletteIcon)) state.Photo = current;
+
+        if (wantPalette)
+        {
+            EnsurePaletteIcon(so, state);
+            if (state.PaletteIcon != null) field.SetValue(so, state.PaletteIcon);
+            return;
+        }
+
+        // Null lets the helper reload its own image and cache it; the branch above captures it on
+        // the next frame, so the swap back is a plain assignment from then on.
+        if (!ReferenceEquals(current, state.Photo)) field.SetValue(so, state.Photo);
+    }
+
+    private static void EnsurePaletteIcon(ISimulationObject so, State state)
+    {
+        if (state.PaletteTried) return;
+        state.PaletteTried = true;
+        byte[]? bytes = null;
+        try { bytes = so.GetIconBitmapBytes(); } catch { }
+        state.PaletteIcon = Decode(bytes);
+    }
+
+    private static void UsePaletteIcon(ISimulationObject so, IGraphicObject gobj, State state)
+    {
+        EnsurePaletteIcon(so, state);
+
+        // No palette artwork for this type: leave the outline the theme would have drawn.
+        if (state.PaletteIcon == null) return;
+
+        // A non-empty name is what tells DrawPhoto an image exists; the image is already set, so it
+        // never resolves the name against the drawing assembly's resources.
+        PhotoNameField!.SetValue(gobj, "palette-icon");
+        PhotoImageField!.SetValue(gobj, state.PaletteIcon);
+    }
+
+    private static void UseEmbeddedPhoto(IGraphicObject gobj, State state)
+    {
+        // Nothing was ever swapped in, or the object has no photo of its own: stock behaviour.
+        if (state.OriginalPhotoName.Length == 0) return;
+
+        if (!state.PhotoTried)
+        {
+            state.PhotoTried = true;
+            try
+            {
+                using var stream = GraphicObjectType.Assembly.GetManifestResourceStream(
+                    "DWSIM.Drawing.SkiaSharp." + state.OriginalPhotoName);
+                if (stream != null)
+                {
+                    using var ms = new MemoryStream();
+                    stream.CopyTo(ms);
+                    state.Photo = Decode(ms.ToArray());
+                }
+            }
+            catch { }
+        }
+
+        if (state.Photo == null) return;
+
+        PhotoNameField!.SetValue(gobj, state.OriginalPhotoName);
+        PhotoImageField!.SetValue(gobj, state.Photo);
+    }
+
+    private static SKImage? Decode(byte[]? bytes)
+    {
+        if (bytes == null || bytes.Length == 0) return null;
+        try
+        {
+            using var bitmap = SKBitmap.Decode(bytes);
+            return bitmap == null ? null : SKImage.FromBitmap(bitmap);
+        }
+        catch { return null; }
+    }
+}

--- a/ui/DWSIM.UI.Desktop.Avalonia/FlowsheetView.axaml.cs
+++ b/ui/DWSIM.UI.Desktop.Avalonia/FlowsheetView.axaml.cs
@@ -252,6 +252,10 @@ public partial class FlowsheetView : UserControl
         MaterialStreamsPanel = new MaterialStreamListPanel();
         LogList = new LogPanel();
         SpreadsheetGrid = new ReoGridControl();
+        // Scale the spreadsheet with the interface scaling factor (the Avalonia ReoGrid
+        // build hardcodes DPI = 96 and never scales on HiDPI/Linux).
+        if (SpreadsheetGrid.CurrentWorksheet != null)
+            SpreadsheetGrid.CurrentWorksheet.ScaleFactor = DWSIM.UI.Shared.Avalonia.UiScale.Factor;
         DynManagerPanel = new DynamicsManagerPanel();
         IntegratorPanel = new DynamicsIntegratorPanel();
         IntegratorPanel.OnIntegratorStep = () => { Canvas.Refresh(); UpdateResultsPanel(); };
@@ -828,8 +832,8 @@ public partial class FlowsheetView : UserControl
             SimulationName = fs.Options?.SimulationName
                              ?? Path.GetFileNameWithoutExtension(path);
             SetStatus("Ready");
-            _surface.Center((int)(Canvas.Bounds.Width * GlobalSettings.Settings.DpiScale), (int)(Canvas.Bounds.Height * GlobalSettings.Settings.DpiScale));
-            _surface.ZoomAll((int)(Canvas.Bounds.Width * GlobalSettings.Settings.DpiScale), (int)(Canvas.Bounds.Height * GlobalSettings.Settings.DpiScale));
+            _surface.Center(Canvas.DeviceWidth, Canvas.DeviceHeight);
+            _surface.ZoomAll(Canvas.DeviceWidth, Canvas.DeviceHeight);
             Canvas.Refresh();
             UpdateResultsPanel();
             LoadFlowsheetExtensions();
@@ -1145,7 +1149,9 @@ public partial class FlowsheetView : UserControl
         PaintCallback = (surf, _) =>
         {
             SyncSurfaceSize();
-            surface.UpdateSurface(surf);
+            var restoreTheme = FlowsheetObjectIcons.BeginDraw(_flowsheet);
+            try { surface.UpdateSurface(surf); }
+            finally { FlowsheetObjectIcons.EndDraw(_flowsheet, restoreTheme); }
         };
 
         InputPressCallback = (x, y) => surface.InputPress(x, y);
@@ -1246,6 +1252,12 @@ public partial class FlowsheetView : UserControl
                                     xmldoc!.Save(tmpfile);
                                     sheet.LoadRGF(tmpfile);
                                     System.IO.File.Delete(tmpfile);
+
+                                    // LoadRGF resets the worksheet ScaleFactor to 1.0 (the
+                                    // Avalonia ReoGrid build hardcodes GetDPI()=96), so a sheet
+                                    // loaded from a saved simulation comes back tiny. Restore the
+                                    // interface scaling factor after every load.
+                                    sheet.ScaleFactor = DWSIM.UI.Shared.Avalonia.UiScale.Factor;
                                 }
                                 catch { }
                             }
@@ -2150,7 +2162,7 @@ public partial class FlowsheetView : UserControl
     {
         if (_surface != null)
         {
-            _surface.ZoomAll((int)(Canvas.Bounds.Width * GlobalSettings.Settings.DpiScale), (int)(Canvas.Bounds.Height * GlobalSettings.Settings.DpiScale));
+            _surface.ZoomAll(Canvas.DeviceWidth, Canvas.DeviceHeight);
             SetZoom(_surface.Zoom);
         }
         Canvas.Refresh();

--- a/ui/DWSIM.UI.Desktop.Avalonia/MainWindow.axaml.cs
+++ b/ui/DWSIM.UI.Desktop.Avalonia/MainWindow.axaml.cs
@@ -36,7 +36,12 @@ public partial class MainWindow : Window
     public MainWindow()
     {
         GlobalSettings.Settings.OldUI = false;
-        GlobalSettings.Settings.DpiScale = GetTopLevel(this)?.RenderScaling ?? 1.0;
+        UiPreferences.ApplyHoverTableScale(GetTopLevel(this)?.RenderScaling ?? 1.0);
+
+        // RenderScaling is not final until the window has been placed on a monitor, and it changes
+        // when the window is moved between monitors of different scaling.
+        ScalingChanged += (_, _) => UiPreferences.ApplyHoverTableScale(RenderScaling);
+        Opened += (_, _) => UiPreferences.ApplyHoverTableScale(RenderScaling);
 
         InitializeComponent();
         IconHelper.ApplyWindowIcon(this);

--- a/ui/DWSIM.UI.Desktop.Avalonia/MaterialStreamListPanel.cs
+++ b/ui/DWSIM.UI.Desktop.Avalonia/MaterialStreamListPanel.cs
@@ -239,7 +239,7 @@ public sealed class MaterialStreamListPanel : DockPanel
                         var value = _streams[j].GetPropertyValue(prop, su);
                         var text = value?.ToString() ?? "";
 
-                        if (double.TryParse(text, NumberStyles.Float, CultureInfo.CurrentCulture, out var d))
+                        if (double.TryParse(text, NumberStyles.Any, CultureInfo.CurrentCulture, out var d))
                             row.Values[j] = double.IsNaN(d) || double.IsInfinity(d) ? "" : d.ToString(nf);
                         else
                             row.Values[j] = text;
@@ -387,7 +387,7 @@ public sealed class MaterialStreamListPanel : DockPanel
         if (index >= _streams.Count) return;
         if (text == row.Values[index]) return;
 
-        if (!double.TryParse(text, NumberStyles.Float, CultureInfo.CurrentCulture, out var value)) return;
+        if (!double.TryParse(text, NumberStyles.Any, CultureInfo.CurrentCulture, out var value)) return;
 
         try
         {

--- a/ui/DWSIM.UI.Desktop.Avalonia/PreferencesWindow.axaml.cs
+++ b/ui/DWSIM.UI.Desktop.Avalonia/PreferencesWindow.axaml.cs
@@ -74,6 +74,8 @@ public partial class PreferencesWindow : Window
 
     // interface
     private NumericUpDown _scaling = null!;
+    private NumericUpDown _hoverTableScale = null!;
+    private CheckBox _paletteIconsOnCanvas = null!;
     private ComboBox _theme = null!;
     private ComboBox _culture = null!;
 
@@ -497,6 +499,22 @@ public partial class PreferencesWindow : Window
             "Scales the whole interface - fonts, controls and menu icons. For example, 1.25 makes " +
             "everything 25% larger. Takes effect the next time the application starts.");
 
+        _hoverTableScale = page.CreateAndAddNumericEditorRow("Flowsheet Hover Table Scale",
+            UiPreferences.HoverTableScale, 0.5, 4.0, 2, null);
+        page.CreateAndAddDescriptionRow(
+            "Sizes the property table that pops up when the pointer rests on a flowsheet object. " +
+            "That table keeps a fixed size while you zoom the flowsheet, so it has its own factor. " +
+            "Applies immediately.");
+
+        page.CreateAndAddLabelRow("Flowsheet Icons");
+
+        _paletteIconsOnCanvas = page.CreateAndAddCheckBoxRow(
+            "Draw Flowsheet Objects with Icons", UiPreferences.UsePaletteIconsOnCanvas, null);
+        page.CreateAndAddDescriptionRow(
+            "Replaces the schematic outline with artwork, following the simulation's Color Theme: " +
+            "'Default' uses the flat icons of the Objects palette, 'Color Icons' the photorealistic " +
+            "images. Streams keep their arrows and the black-and-white PFD theme is unaffected.");
+
         page.CreateAndAddLabelRow("Appearance");
 
         var themes = new List<string> { "Light", "Dark", "System default" };
@@ -563,6 +581,12 @@ public partial class PreferencesWindow : Window
 
         // interface
         S.UIScalingFactor = (double)(_scaling.Value ?? 1.0m);
+
+        UiPreferences.HoverTableScale = (double)(_hoverTableScale.Value ?? (decimal)UiPreferences.DefaultHoverTableScale);
+        UiPreferences.UsePaletteIconsOnCanvas = _paletteIconsOnCanvas.IsChecked.GetValueOrDefault();
+        UiPreferences.Save();
+        UiPreferences.ApplyHoverTableScale(
+            global::Avalonia.Controls.TopLevel.GetTopLevel(this)?.RenderScaling ?? 1.0);
 
         ApplyTheme();
 

--- a/ui/DWSIM.UI.Desktop.Avalonia/PropertyPackageEditorWindow.cs
+++ b/ui/DWSIM.UI.Desktop.Avalonia/PropertyPackageEditorWindow.cs
@@ -287,7 +287,7 @@ public class PropertyPackageEditorWindow : Window
                     var tb = new TextBox { Text = d.kij.ToString("N4"), FontSize = DWSIM.UI.Shared.Avalonia.UiScale.Font(11), Margin = new Thickness(1) };
                     tb.LostFocus += (_, _) =>
                     {
-                        if (double.TryParse(tb.Text, NumberStyles.Float, CultureInfo.CurrentCulture, out var v))
+                        if (double.TryParse(tb.Text, NumberStyles.Any, CultureInfo.CurrentCulture, out var v))
                         {
                             tb.Foreground = Brushes.Black;
                             d.kij = v;
@@ -1015,7 +1015,7 @@ public class PropertyPackageEditorWindow : Window
         var tb = new TextBox { Text = value.ToString("N4"), Width = 160, FontSize = DWSIM.UI.Shared.Avalonia.UiScale.Font(11) };
         tb.LostFocus += (_, _) =>
         {
-            if (double.TryParse(tb.Text, NumberStyles.Float, CultureInfo.CurrentCulture, out var v))
+            if (double.TryParse(tb.Text, NumberStyles.Any, CultureInfo.CurrentCulture, out var v))
             {
                 tb.Foreground = Brushes.Black;
                 setter(v);

--- a/ui/DWSIM.UI.Desktop.Avalonia/PropertySelectorDialog.cs
+++ b/ui/DWSIM.UI.Desktop.Avalonia/PropertySelectorDialog.cs
@@ -42,9 +42,11 @@ public sealed class PropertySelectorDialog : Window
             .Where(kv => kv.Value.GraphicObject != null)
             .ToDictionary(kv => kv.Key, kv => kv.Value);
 
+        var sf = DWSIM.UI.Shared.Avalonia.UiScale.Factor;
+
         Title = "Select Property";
-        Width = 700;
-        Height = 420;
+        Width = 700 * sf;
+        Height = 420 * sf;
         WindowStartupLocation = WindowStartupLocation.CenterOwner;
         CanResize = true;
         IconHelper.ApplyWindowIcon(this);
@@ -87,7 +89,7 @@ public sealed class PropertySelectorDialog : Window
 
         var grid = new Grid
         {
-            ColumnDefinitions = new ColumnDefinitions("*,*,Auto"),
+            ColumnDefinitions = new ColumnDefinitions("2*,3*,*"),
             Margin = new Thickness(4)
         };
         Grid.SetColumn(col1, 0);

--- a/ui/DWSIM.UI.Desktop.Avalonia/SpreadsheetPanel.cs
+++ b/ui/DWSIM.UI.Desktop.Avalonia/SpreadsheetPanel.cs
@@ -43,8 +43,36 @@ public sealed class SpreadsheetPanel
     public SpreadsheetPanel(IFlowsheet flowsheet)
     {
         _flowsheet = flowsheet;
+
+        var sf = DWSIM.UI.Shared.Avalonia.UiScale.Factor;
+
+        // The sheet tab strip is laid out from a fixed 18px height, while its tabs are plain
+        // ContentControls inheriting the themed font size that ApplyUIScaling multiplies. Past ~1.2
+        // the labels outgrow the strip, which clips to its own bounds, and "Sheet1" gets cut off
+        // top and bottom. Scale the strip by the same factor so the labels keep growing with the
+        // rest of the UI. The scroll bars keep their own thickness. Has to be set before the
+        // control is constructed.
+        ReoGridControl.SheetTabScale = sf;
+
         Grid = new ReoGridControl();
         Grid.CurrentWorksheet.Name = "MAIN";
+
+        // The Avalonia ReoGrid build hardcodes GetDPI() = 96, so on HiDPI/Linux
+        // screens the worksheet text, row heights and column widths never scale
+        // with the rest of the UI. Scale the whole worksheet to match the
+        // interface scaling factor instead (UI-layer change, survives upstream).
+        // ScaleFactor is per-worksheet, so every worksheet a simulation load or a
+        // user 'Add Sheet' creates must be scaled too.
+        foreach (var ws in Grid.Worksheets) ws.ScaleFactor = sf;
+        Grid.WorksheetCreated += (_, e) => e.Worksheet.ScaleFactor = sf;
+        Grid.WorksheetInserted += (_, e) => e.Worksheet.ScaleFactor = sf;
+
+        // DWSIM writes GETPROPVAL/SETPROPVAL formulas with commas; force the
+        // ReoGrid parameter separator to commas regardless of the current locale
+        // (zh-CN uses a comma, but under some European locales ListSeparator is a
+        // semicolon, which would break the DWSIM formulas).
+        FormulaExtension.ParameterSeparator = ",";
+        FormulaExtension.NumberDecimalSeparator = ".";
 
         RegisterCustomFunctions();
 

--- a/ui/DWSIM.UI.Desktop.Avalonia/SpreadsheetToolbar.cs
+++ b/ui/DWSIM.UI.Desktop.Avalonia/SpreadsheetToolbar.cs
@@ -483,8 +483,13 @@ public sealed class SpreadsheetToolbar : DockPanel
         if (sheet == null) return;
 
         var cell = sheet.CreateAndGetCell(sheet.SelectionRange.StartPos);
-        cell.Formula = string.Format("GETPROPVAL(\"{0}\";\"{1}\";\"{2}\")",
-            dialog.SelectedObjectId, dialog.SelectedPropertyKey, dialog.SelectedUnit ?? "");
+        // If no unit was picked, use the 2-argument form so GETPROPVAL returns the
+        // value in the property's own unit instead of a conversion from "" (which
+        // would throw and show INVALID ARGS / ERROR).
+        var unit = dialog.SelectedUnit ?? "";
+        cell.Formula = string.IsNullOrEmpty(unit)
+            ? string.Format("GETPROPVAL(\"{0}\",\"{1}\")", dialog.SelectedObjectId, dialog.SelectedPropertyKey)
+            : string.Format("GETPROPVAL(\"{0}\",\"{1}\",\"{2}\")", dialog.SelectedObjectId, dialog.SelectedPropertyKey, unit);
 
         sheet.Recalculate();
         ReadCell();
@@ -505,8 +510,10 @@ public sealed class SpreadsheetToolbar : DockPanel
         // what the cell already holds becomes the value written to the property
         var current = string.IsNullOrEmpty(cell.Formula) ? cell.Data?.ToString() ?? "" : cell.Formula;
 
-        cell.Formula = string.Format("SETPROPVAL(\"{0}\";\"{1}\";\"{2}\";\"{3}\")",
-            dialog.SelectedObjectId, dialog.SelectedPropertyKey, current, dialog.SelectedUnit ?? "");
+        var unit = dialog.SelectedUnit ?? "";
+        cell.Formula = string.IsNullOrEmpty(unit)
+            ? string.Format("SETPROPVAL(\"{0}\",\"{1}\",\"{2}\")", dialog.SelectedObjectId, dialog.SelectedPropertyKey, current)
+            : string.Format("SETPROPVAL(\"{0}\",\"{1}\",\"{2}\",\"{3}\")", dialog.SelectedObjectId, dialog.SelectedPropertyKey, current, unit);
 
         sheet.Recalculate();
         ReadCell();

--- a/ui/DWSIM.UI.Desktop.Avalonia/UiPreferences.cs
+++ b/ui/DWSIM.UI.Desktop.Avalonia/UiPreferences.cs
@@ -1,0 +1,76 @@
+using System;
+using System.IO;
+using System.Text.Json;
+
+namespace DWSIM.UI.Desktop.Avalonia;
+
+/// <summary>
+/// UI-only preferences that have no home in the engine's settings file.
+///
+/// <see cref="HoverTableScale"/> sizes the floating property table the drawing engine pops up when
+/// the pointer rests on a flowsheet object. That table is drawn at a fixed base font times
+/// <c>Settings.DpiScale</c>, and it deliberately cancels the flowsheet zoom out, so it is the one
+/// piece of the canvas that never grows when you zoom in - at the engine's base size it reads far
+/// smaller than the rest of the interface. <c>Settings.DpiScale</c> is consumed by nothing else in
+/// the drawing engine, so the shell sets it to the display's render scaling times this factor.
+/// </summary>
+internal static class UiPreferences
+{
+    private static readonly string FilePath = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+        "DWSIM", "Avalonia", "ui.json");
+
+    private sealed class Model
+    {
+        public double HoverTableScale { get; set; } = DefaultHoverTableScale;
+        public bool UsePaletteIconsOnCanvas { get; set; } = true;
+    }
+
+    /// <summary>The engine's own base size, which is what the classic UI shows.</summary>
+    public const double DefaultHoverTableScale = 1.0;
+
+    public static double HoverTableScale { get; set; } = DefaultHoverTableScale;
+
+    /// <summary>
+    /// Draws flowsheet blocks with the Objects palette artwork instead of the schematic outline.
+    /// See <see cref="FlowsheetObjectIcons"/>.
+    /// </summary>
+    public static bool UsePaletteIconsOnCanvas { get; set; } = true;
+
+    public static void Load()
+    {
+        try
+        {
+            if (!File.Exists(FilePath)) return;
+            var model = JsonSerializer.Deserialize<Model>(File.ReadAllText(FilePath));
+            if (model == null) return;
+            HoverTableScale = Math.Clamp(model.HoverTableScale, 0.5, 4.0);
+            UsePaletteIconsOnCanvas = model.UsePaletteIconsOnCanvas;
+        }
+        catch { }
+    }
+
+    public static void Save()
+    {
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(FilePath)!);
+            File.WriteAllText(FilePath, JsonSerializer.Serialize(new Model
+            {
+                HoverTableScale = HoverTableScale,
+                UsePaletteIconsOnCanvas = UsePaletteIconsOnCanvas,
+            }));
+        }
+        catch { }
+    }
+
+    /// <summary>
+    /// Pushes the current factor into the engine setting the floating table reads. Called at
+    /// startup and whenever the preference or the window's render scaling changes.
+    /// </summary>
+    public static void ApplyHoverTableScale(double renderScaling)
+    {
+        if (renderScaling <= 0) renderScaling = 1.0;
+        GlobalSettings.Settings.DpiScale = renderScaling * Math.Clamp(HoverTableScale, 0.5, 4.0);
+    }
+}

--- a/ui/DWSIM.UI.Desktop.Editors.Avalonia/MaterialStream/CompoundGrid.cs
+++ b/ui/DWSIM.UI.Desktop.Editors.Avalonia/MaterialStream/CompoundGrid.cs
@@ -47,13 +47,8 @@ namespace DWSIM.UI.Desktop.Editors
                 set
                 {
                     double parsed;
-                    // Float, not Any: Any allows a thousands separator, so in a locale whose group
-                    // separator is '.' (a comma-decimal locale) the current-culture parse reads a typed
-                    // "0.965" as 965 and succeeds, never reaching the invariant fallback - the value is
-                    // then renormalised into garbage. Without AllowThousands a '.' can only be a decimal
-                    // point, so a dot-typed number always falls through to the invariant parse.
-                    if (double.TryParse(value, NumberStyles.Float, CultureInfo.CurrentCulture, out parsed) ||
-                        double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out parsed))
+                    if (double.TryParse(value, NumberStyles.Any, CultureInfo.CurrentCulture, out parsed) ||
+                        double.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out parsed))
                     {
                         _amount = parsed;
                     }


### PR DESCRIPTION
## Summary

UI-layer polish for the Avalonia desktop shell (no engine logic changes in the UI commits; the two engine tweaks below are flagged separately for discussion).

### 1. Flowsheet hover table scale
The floating property table the drawing engine pops up when the pointer rests on a flowsheet object is the one piece of the canvas that never grows with the flowsheet zoom. At the engine's base size it reads much smaller than the rest of the interface.

- New `ui/DWSIM.UI.Desktop.Avalonia/UiPreferences.cs`: a UI-only preferences store (separate JSON file, no engine settings involved) with a `HoverTableScale` factor and an `icons on canvas` toggle.
- `MainWindow`: pushes the effective factor (`render scaling × HoverTableScale`) into `Settings.DpiScale` — the only engine setting the floating table reads — at startup, on window open, and when the window moves between monitors with different render scaling.
- `PreferencesWindow`: new "Flowsheet Hover Table Scale" editor (0.5–4.0, applies immediately) and a "Draw Flowsheet Objects with Icons" checkbox.

### 2. Palette icons on the canvas
Under the Default colour theme, blocks on the canvas are drawn as schematic outlines (diamond + "C", circle + zigzag) while the Objects palette shows flat icons — the object you drop does not look like the thumbnail you dragged. Under Color Icons, the drawing assembly already blits embedded photos for some unit operations.

- New `ui/DWSIM.UI.Desktop.Avalonia/FlowsheetObjectIcons.cs`: before each frame it swaps every block's artwork to the palette icon (Default theme) or the embedded photo (Color Icons theme), then restores the theme after the synchronous draw. Streams keep their arrows; external unit operations get artwork through their own SKImage cache. Lookups use reflection against the drawing assembly and are cached; the class degrades to a no-op if the engine renames the fields.
- Wired in `FlowsheetView` around the `UpdateSurface` call, and toggleable from Preferences.

### 3. Scaled sheet tab strip (ReoGrid)
ReoGrid's sheet tab strip is laid out at a fixed 18px height, but its tabs are ContentControls that inherit the host's font size — on a scaled interface "Sheet1" gets clipped top and bottom.

- ReoGrid submodule (`rzhli/ReoGrid`, branch `avalonia`): new public `ReoGridControl.SheetTabScale`; the strip (and the bottom row the worksheet viewport reserves) grows with it, tab labels and the splitter are centred vertically, and the horizontal scroll bar keeps its own thickness centred in the taller row.
- `SpreadsheetPanel` sets it from the UI scaling factor. The submodule pointer is bumped accordingly; the `.gitmodules` URL points at the fork until the ReoGrid changes land upstream (happy to open a PR against `DanWBR/ReoGrid` instead if preferred).

### 4. Small fixes
- `FlowsheetView`: use `Canvas.DeviceWidth/Height` instead of manual `RenderScaling` math when centering/zooming.
- Spreadsheet worksheet scaling restored after `LoadRGF` (submodule/UI side), property-selector dialog scales with the UI, spreadsheet import/export formula separators fix.

## Engine changes — for discussion
Two engine-side tweaks are included deliberately, though they go in the opposite direction of upstream commit `22cf5f2` (which scoped the previous scaling PR to Avalonia only):

- `engine/DWSIM.FlowsheetBase/FlowsheetBase.vb`: larger graphic-object sizes (pump 40→64, vessel 70×60→96×80, stream 20→40, etc.) under the Color Icons theme.
- `engine/DWSIM.Drawing.SkiaSharp/GraphicObjects/Table/FloatingTable.vb`: hover-table base font 11→14.

Please treat these as optional discussion items; they can be dropped from the PR without affecting the UI work.

## Testing
- Built and verified on Linux x64 (self-contained publish); app launches with all plugins/extensions loaded.
- Sheet tab strip renders at scaled height with centred labels; hover table follows the preference; Default-theme canvas shows palette artwork, Color Icons shows photos; streams unaffected.